### PR TITLE
Adds Functions for API Keys and AssetDirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 .DS_STORE
-./InedOps
-/InedOps
-./InedOps/*
-InedOps
 bin
 /mkdocs/site
-/1.0.0
+[0-9]\.[0-9]\.[0-9]

--- a/Build.psd1
+++ b/Build.psd1
@@ -1,6 +1,6 @@
 @{
     ModuleManifest           = "./source/Pagootle.psd1"
-    #CopyDirectories          = "data"
+    CopyDirectories          = "data"
     Suffix                   = "Suffix.ps1"
     OutputDirectory          = ".."
     VersionedOutputDirectory = $true

--- a/source/Pagootle.psd1
+++ b/source/Pagootle.psd1
@@ -63,7 +63,7 @@ RequiredModules = @(@{ModuleName='Configuration' ; ModuleVersion = '1.6.0'})
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+FormatsToProcess = @("data\Pagootle.Format.ps1xml")
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/source/Suffix.ps1
+++ b/source/Suffix.ps1
@@ -1,0 +1,1 @@
+$script:CurrentConfiguration = "Default"

--- a/source/classes/10-ProGetAssetDirectoryItem.ps1
+++ b/source/classes/10-ProGetAssetDirectoryItem.ps1
@@ -1,0 +1,33 @@
+class ProGetAssetDirectoryItem {
+    # See: https://github.com/Inedo/pgutil/blob/thousand/Inedo.ProGet/AssetDirectories/AssetDirectoryItem.cs
+    [string]$AssetDirectory
+    [string]$Name        # The name of the Asset item (File or Folder)
+    [string]$Parent      # The full path of the parent directory of the item
+    [int64]$Size         # The number of bytes in size of the item.
+    [string]$Type        # Either the Content-Type of the the item, or "dir" if the item represents a folder.
+    [string]$Content     # The full URL of the item.
+    [datetime]$Created   # The UTC date of the original creation time of the item
+    [datetime]$Modified  # The UTC date of the last time of the item was updated
+    [string]$MD5         # The MD5 hash of the item in hexadecimal format
+    [string]$SHA1        # The SHA1 hash of the item in hexadecimal format
+    [string]$SHA256      # The SHA256 hash of the item in hexadecimal format
+    [string]$SHA512      # The SHA512 hash of the item in hexadecimal format
+    $UserMetadata
+    $CacheHeader
+
+    ProGetAssetDirectoryItem ($InputObject) {
+        $this.AssetDirectory = $InputObject.content -replace '^(?<Endpoint>.+)/endpoints/(?<AssetDirectory>.+?)/content/(?<FileName>.+)$', '${AssetDirectory}'
+        $this.Modified = [DateTime]::Parse($InputObject.Modified, ([cultureinfo]::new("en-US", $false)), "AssumeUniversal")
+        $this.Created = [DateTime]::Parse($InputObject.Created, ([cultureinfo]::new("en-US", $false)), "AssumeUniversal")
+        
+        foreach ($Property in $InputObject.PSObject.Properties.Name) {
+            if ($this.PSObject.Properties.Where{$_.MemberType -eq 'Property'}.Name -contains $Property) {
+                if (-not $this.$Property) {
+                    $this.$Property = $InputObject.$Property
+                }
+            } else {
+                Write-Debug "Unexpected property '$Property' found."
+            }
+        }
+    }
+}

--- a/source/classes/10-ProGetAssetDirectoryItem.ps1
+++ b/source/classes/10-ProGetAssetDirectoryItem.ps1
@@ -19,7 +19,7 @@ class ProGetAssetDirectoryItem {
         $this.AssetDirectory = $InputObject.content -replace '^(?<Endpoint>.+)/endpoints/(?<AssetDirectory>.+?)/content/(?<FileName>.+)$', '${AssetDirectory}'
         $this.Modified = [DateTime]::Parse($InputObject.Modified, ([cultureinfo]::new("en-US", $false)), "AssumeUniversal")
         $this.Created = [DateTime]::Parse($InputObject.Created, ([cultureinfo]::new("en-US", $false)), "AssumeUniversal")
-        
+
         foreach ($Property in $InputObject.PSObject.Properties.Name) {
             if ($this.PSObject.Properties.Where{$_.MemberType -eq 'Property'}.Name -contains $Property) {
                 if (-not $this.$Property) {

--- a/source/classes/11-ProGetApiKey.ps1
+++ b/source/classes/11-ProGetApiKey.ps1
@@ -1,0 +1,46 @@
+class ProGetApiKey {
+    # See: https://github.com/steviecoaster/Pagootle/blob/main/source/private/Invoke-NewUserStoredProc.ps1
+    [int]$Id                                            # ProGet-generated unique ID for an API key; used when deleting a key and can never be set
+    [ProGetApiKeyType]$Type                             # Type of API key; may be feed, feedgroup?, system, user
+    [securestring]$SecureKey                            # Api may provide Api Key text itself if hashing is disabled; This is a securestring version of that.
+    [string]$DisplayName                                # Used in lists of keys, and when not specified, a name like "(ID=1000)" is displayed
+    [string]$Description                                # Used to describe the usage or other context about the key
+    [datetime]$Expiration                               # Expiry of the key; if unset, will currently present as 0001-01-01 ([datetime]0)
+    [string]$User                                       # Name of the user the personal key applies to; required when Type is Personal (otherwise must be null)
+    [ProGetApiKeyPackagePermission]$PackagePermissions  # Permissions a feed key may have; Value is a combination of "view","add","promote","delete"
+    hidden [ProGetApiKeySystemApis]$_SystemApis         # APIs a system key may use; Value is either ["full-control"] or a combination of "feeds", "sca", "sbom-upload"
+    [string]$Feed                                       # Name of the feed the feed key applies to
+    [string]$FeedGroup                                  # Name of the feed group the key applies to
+    $Logging
+
+    ProGetApiKey ($InputObject) {
+        # Handle conversion of the SystemApis back into enum friendly characters
+        if ($InputObject.SystemApis.Count) {
+            $TempSystemApis = @()
+            $InputObject.SystemApis.ForEach{
+                $TempSystemApis += $_ -replace '-','_'
+            }
+            $this._SystemApis = $TempSystemApis
+        }
+        # Add a "read-only" property to access SystemApis, so it doesn't try and cast bad values later
+        $this.PSObject.Properties.Add(
+            (New-Object PSScriptProperty 'SystemApis', {$this._SystemApis})
+        )
+
+        # The key may not be available if hashing is enabled
+        if ($InputObject.Key) {
+            $this.SecureKey = ConvertTo-SecureString $InputObject.Key -AsPlainText -Force
+        }
+
+        # Grab any missing properties and assign them
+        foreach ($Property in $InputObject.PSObject.Properties.Name) {
+            if ($this.PSObject.Properties.Where{$_.MemberType -eq 'Property'}.Name -contains $Property) {
+                if (-not $this.Property) {
+                    $this.$Property = $InputObject.$Property
+                }
+            } else {
+                Write-Debug "Unexpected property '$Property' found."
+            }
+        }
+    }
+}

--- a/source/data/Pagootle.Format.ps1xml
+++ b/source/data/Pagootle.Format.ps1xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+    <SelectionSets>
+        <SelectionSet>
+            <Name>PagootleTypes</Name>
+            <Types>
+                <TypeName>ProGetAssetDirectoryItem</TypeName>
+                <TypeName>ProGetApiKey</TypeName>
+                <TypeName>ProGetAssetItemMetadata</TypeName>
+            </Types>
+        </SelectionSet>
+    </SelectionSets>
+    <!-- ################ CONTROL DEFINITIONS ################ -->
+    <Controls>
+        <Control>
+            <Name>ProGetAssetDirectoryItem-GroupingFormat</Name>
+            <CustomControl>
+                <CustomEntries>
+                    <CustomEntry>
+                        <CustomItem>
+                            <Frame>
+                                <LeftIndent>4</LeftIndent>
+                                <CustomItem>
+                                    <Text>Folder: </Text>
+                                    <ExpressionBinding>
+                                        <ScriptBlock>
+                                            "/" + $_.Parent
+                                        </ScriptBlock>
+                                    </ExpressionBinding>
+                                </CustomItem>
+                            </Frame>
+                        </CustomItem>
+                    </CustomEntry>
+                </CustomEntries>
+            </CustomControl>
+        </Control>
+    </Controls>
+    <ViewDefinitions>
+        <View>
+            <Name>ProGetAssetDirectoryItem</Name>
+            <ViewSelectedBy>
+                <TypeName>ProGetAssetDirectoryItem</TypeName>
+            </ViewSelectedBy>
+            <GroupBy>
+                <PropertyName>Parent</PropertyName>
+                <CustomControlName>ProGetAssetDirectoryItem-GroupingFormat</CustomControlName>
+            </GroupBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Name</Label>
+                        <Alignment>Left</Alignment>
+                        <Width>58</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Modified</Label>
+                        <Width>20</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Size</Label>
+                        <Width>12</Width>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($PSStyle) {  # Pwsh
+                                        if ($_.Type -eq 'dir') {
+                                            "$($PSStyle.FileInfo.Directory)$($_.Name)$($PSStyle.Reset)"
+                                        } elseif ($PSStyle.FormatHyperlink -and $_.Content) {
+                                            "$($PSStyle.FormatHyperlink($_.Name, $_.Content))$($PSStyle.Reset)"
+                                        }
+                                    } elseif ($Host.PrivateData) {  # PowerShell, not a good test
+                                        if ($_.Type -eq 'dir') {
+                                            "$([char]27)[7;$(37);$(44)m$($_.Name)$([char]27)[0m"
+                                        #} elseif ($_.Content) {
+                                        #    "$([char]27)]8;;$($_.Content)`a$($_.Name)$([char]27)]8;;`a"  # TODO: Fix this
+                                        } else {
+                                            $_.Name
+                                        }
+                                    } else {  # Fallback
+                                        $_.Name
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Modified</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <Alignment>Right</Alignment>
+                                <ScriptBlock>
+                                    switch ($_.Size) {
+                                        {$_ -lt 1KB} {return "$($_)  B"}
+                                        {$_ -lt 1MB} {return "$([Math]::Round($_ / 1KB, 2)) KB"}
+                                        {$_ -lt 1GB} {return "$([Math]::Round($_ / 1MB, 2)) MB"}
+                                        {$_ -ge 1GB} {return "$([Math]::Round($_ / 1GB, 2)) GB"}
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>ProGetAssetItemMetadata</Name>
+            <ViewSelectedBy>
+                <TypeName>ProGetAssetItemMetadata</TypeName>
+            </ViewSelectedBy>
+            <GroupBy>
+                <PropertyName>Parent</PropertyName>
+                <CustomControlName>ProGetAssetDirectoryItem-GroupingFormat</CustomControlName>
+            </GroupBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Name</Label>
+                        <Alignment>Left</Alignment>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Type</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>UserMetadata</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>CacheHeader</Label>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    $_.Type.Split(';')[0]
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>UserMetadata</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>CacheHeader</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                        <Wrap/>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>ProGetApiKey</Name>
+            <ViewSelectedBy>
+                <TypeName>ProGetApiKey</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Label>Id</Label>
+                        <Alignment>Left</Alignment>
+                        <Width>4</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Name/Description</Label>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Type</Label>
+                        <Width>8</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Permissions</Label>
+                        <Width>40</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Label>Expiration</Label>
+                        <Width>12</Width>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Id</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    "$(if ($_.DisplayName) {$_.DisplayName} else {"(id=$($_.Id))"})`n$(if($_.Description){"$($PSStyle.Dim)$($_.Description)$($PSStyle.Reset)"})"
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Type</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    $Current = $_
+                                    switch ($Current.Type) {
+                                        "system" {
+                                            $Current.SystemApis
+                                        }
+                                        "user" {
+                                            $Current.User
+                                        }
+                                        "feed" {
+                                            if ($Current.Feed) {
+                                                @(
+                                                    "$($Current.PackagePermissions -join ', ')"
+                                                    "`n(in feed"
+                                                    $Current.Feed + ')'
+                                                ) -join ' '
+                                            } elseif ($Current.FeedGroup) {
+                                                @(
+                                                    "$($Current.PackagePermissions -join ', ')"
+                                                    "`n(in feed group"
+                                                    $Current.FeedGroup + ')'
+                                                ) -join ' '
+                                            } else {
+                                                @(
+                                                    "$($Current.PackagePermissions -join ', ')"
+                                                    "`n(in all feeds)"
+                                                ) -join ' '
+                                            }
+                                        }
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <ScriptBlock>
+                                    if ($_.Expiration -gt 0) {
+                                        '{0:yyyy}-{0:MMM}-{0:dd}' -f $_.Expiration
+                                    } else {
+                                        "Not Set"
+                                    }
+                                </ScriptBlock>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                        <Wrap/>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/source/enum/10-ProGetApiKeyType.ps1
+++ b/source/enum/10-ProGetApiKeyType.ps1
@@ -1,0 +1,6 @@
+enum ProGetApiKeyType {
+    system
+    feed
+    personal
+    other
+}

--- a/source/enum/11-ProGetApiKeyPackagePermission.ps1
+++ b/source/enum/11-ProGetApiKeyPackagePermission.ps1
@@ -1,0 +1,6 @@
+[Flags()] enum ProGetApiKeyPackagePermission {
+    view = 1
+    add = 2
+    promote = 4
+    delete = 8
+}

--- a/source/enum/12-ProGetApiKeySystemApis.ps1
+++ b/source/enum/12-ProGetApiKeySystemApis.ps1
@@ -1,0 +1,6 @@
+[Flags()] enum ProGetApiKeySystemApis {
+    feeds = 1
+    sca = 2
+    sbom_upload = 4
+    full_control = 7  # Full control is the combination of all other values
+}

--- a/source/private/CopyMaxBytes.ps1
+++ b/source/private/CopyMaxBytes.ps1
@@ -31,7 +31,7 @@ function CopyMaxBytes {
             $totalBytesRead += $bytesRead
             if ($totalBytesRead -ge $maxBytes) { break }
             $overallProgress = $startOffset + $totalBytesRead
-            Write-Progress -Activity "Uploading $fileName..." -Status "$overallProgress/$totalSize" -PercentComplete ($overallProgress / $totalSize * 100)
+            Write-Progress -Activity "Uploading $Path..." -Status "$overallProgress/$totalSize" -PercentComplete ($overallProgress / $totalSize * 100)
         }
     }
 }

--- a/source/private/CreateApiKeyFromCredential.ps1
+++ b/source/private/CreateApiKeyFromCredential.ps1
@@ -1,0 +1,18 @@
+function CreateApiKeyFromCredential {
+    [CmdletBinding()]
+    param(
+        [PSCredential]$Credential,
+        [string]$Name
+    )
+    $Configuration.Add('ApiKey', $Credential.Password)
+
+    Write-Verbose "Using Credential '$($Credential.UserName)' to create API key for usage..."
+    $Configuration | Export-Configuration -CompanyName "Pagootle" -Name $Name
+
+    $ApiKeyRequest = @{
+        DisplayName = "PagootleAccess"
+        Description = "An API key created for use with Pagootle."
+        SystemAPI   = "full_control"
+    }
+    (New-ProGetApiKey @ApiKeyRequest).SecureKey
+}

--- a/source/private/DownloadProGetFile.ps1
+++ b/source/private/DownloadProGetFile.ps1
@@ -1,0 +1,53 @@
+function DownloadProGetFile {
+    <#
+    .SYNOPSIS
+    Downloads a file from ProGet
+
+    .DESCRIPTION
+    Downloads a file from the currently active ProGet server.
+
+    .EXAMPLE
+
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string]$Slug,
+
+        [string]$OutputPath,
+
+        [switch]$PassThru
+    )
+    begin {
+        $Configuration = Get-ProGetConfiguration
+
+        $ApiCredential = if ($Configuration.ApiKey) {
+            $Configuration.ApiKey.GetNetworkCredential().Password
+        } elseif ($Configuration.Credential) {
+            $Configuration.Credential.GetNetworkCredential().Password
+        }
+        
+        $Downloader = [System.Net.WebClient]::new()
+        $Downloader.Headers.Add("X-ApiKey", $ApiCredential)
+    }
+    process {
+        $SavePath = if (Test-Path $OutputPath -PathType Container) {
+            Join-Path $OutputPath (Split-Path ([uri]"$($Configuration.EndpointUrl.TrimEnd('/'))/$($Slug.TrimStart('/'))").LocalPath -Leaf)
+        } else {
+            if (-not (Test-Path ($ParentDir = Split-Path $OutputPath -Parent) -PathType Container)) {
+                $null = mkdir $ParentDir -Force
+            }
+            $OutputPath
+        }
+
+        Write-Verbose "[GET] '$($Configuration.EndpointUrl.TrimEnd('/'))/$($Slug.TrimStart('/'))' -> '$($SavePath)'"
+        $Downloader.DownloadFile("$($Configuration.EndpointUrl.TrimEnd('/'))/$($Slug.TrimStart('/'))", $SavePath)
+
+        if ($PassThru) {
+            Get-Item $SavePath
+        }
+    }
+    end {
+        $Downloader.Dispose()
+    }
+}

--- a/source/private/Invoke-ProGet.ps1
+++ b/source/private/Invoke-ProGet.ps1
@@ -27,7 +27,11 @@ function Invoke-ProGet {
 
         [Parameter()]
         [String]
-        $ContentType = 'application/json'
+        $ContentType = 'application/json',
+
+        [Parameter()]
+        [hashtable]
+        $AdditionalParameters
     )
     begin {
         $Configuration = Get-ProGetConfiguration
@@ -43,14 +47,14 @@ function Invoke-ProGet {
         else {
             @{Protocol = 'http'; Port = $Configuration['NonSslPort'] }
         }
-        $Uri = '{0}:{1}{2}' -f "$($ssl['Protocol'])://$($Configuration['Hostname'])", $ssl['Port'], $Slug.TrimEnd('/')
+        $Uri = '{0}:{1}/{2}' -f "$($ssl['Protocol'])://$($Configuration['Hostname'])", $ssl['Port'], $Slug.TrimStart('/').TrimEnd('/')
         $ApiHeader = if ($caller -notin $ApiKeyRequests -and $Configuration.Credential) {
             @{'X-ApiKey' = $Configuration.Credential.GetNetworkCredential().Password }
         } elseif ($Configuration.ApiKey) {
             @{'X-ApiKey' = $Configuration.ApiKey.GetNetworkCredential().Password }
         }
 
-        Write-Verbose -Message $Uri
+        
         $params = @{
             Uri                  = $Uri
             Method               = $Method
@@ -81,10 +85,15 @@ function Invoke-ProGet {
             $fileContent = [System.IO.File]::ReadAllBytes($File)
             $params['Body'] = $fileContent
             $params['ContentType'] = 'application/octet-stream'
-            Write-Verbose $params.Uri
         }
 
-        #Write-Verbose ($Body | ConvertTo-Json -Depth 5)
+        if ($AdditionalParameters) {
+            $AdditionalParameters.GetEnumerator().ForEach{
+                $params.$_ = $AdditionalParameters.$_
+            }
+        }
+
+        Write-Verbose "[$($Method.ToUpper())] $($Uri)"
         Invoke-RestMethod @params
     }
 }

--- a/source/private/Invoke-ProGet.ps1
+++ b/source/private/Invoke-ProGet.ps1
@@ -29,16 +29,14 @@ function Invoke-ProGet {
         [String]
         $ContentType = 'application/json'
     )
-
     begin {
         $Configuration = Get-ProGetConfiguration
         
-        # If we call this from New-ProGetFeed we have to use a special API key because ProGet is...well, silly.
+        # If we call this from some commands we have to use a special API key.
         $caller = (Get-PSCallStack)[1].Command
+        $ApiKeyRequests = @('New-ProGetFeed', 'Get-ProGetAssetDirectoryItem')
     }
-
     end {
-
         $ssl = if ($Configuration['UseSSL']) {
             @{Protocol = 'https' ; Port = $Configuration['SslPort'] }
         }
@@ -46,20 +44,24 @@ function Invoke-ProGet {
             @{Protocol = 'http'; Port = $Configuration['NonSslPort'] }
         }
         $Uri = '{0}:{1}{2}' -f "$($ssl['Protocol'])://$($Configuration['Hostname'])", $ssl['Port'], $Slug.TrimEnd('/')
+        $ApiHeader = if ($caller -notin $ApiKeyRequests -and $Configuration.Credential) {
+            @{'X-ApiKey' = $Configuration.Credential.GetNetworkCredential().Password }
+        } elseif ($Configuration.ApiKey) {
+            @{'X-ApiKey' = $Configuration.ApiKey.GetNetworkCredential().Password }
+        }
 
         Write-Verbose -Message $Uri
         $params = @{
             Uri                  = $Uri
             Method               = $Method
             ContentType          = $ContentType
-            Headers              = if ($caller -ne 'New-ProGetFeed') {
-                @{'X-ApiKey' = $Configuration.Credential.GetNetworkCredential().Password }
-            } 
-            else {
-                @{'X-ApiKey' = $Configuration.ApiKey.GetNetworkCredential().Password }
-            }
-            SkipCertificateCheck = $true
+            Headers              = $ApiHeader
             Verbose              = $false
+        }
+
+        if ((Get-Command Invoke-RestMethod).Parameters.SkipCertificateCheck) {
+            # We should probably remove this?
+            $params.SkipCertificateCheck = $true
         }
 
         if ($Body) {

--- a/source/private/Invoke-ProGet.ps1
+++ b/source/private/Invoke-ProGet.ps1
@@ -35,36 +35,19 @@ function Invoke-ProGet {
     )
     begin {
         $Configuration = Get-ProGetConfiguration
-        
-        # If we call this from some commands we have to use a special API key.
-        $caller = (Get-PSCallStack)[1].Command
-        $ApiKeyRequests = @('New-ProGetFeed', 'Get-ProGetAssetDirectoryItem')
     }
     end {
-        $ssl = if ($Configuration['UseSSL']) {
-            @{Protocol = 'https' ; Port = $Configuration['SslPort'] }
-        }
-        else {
-            @{Protocol = 'http'; Port = $Configuration['NonSslPort'] }
-        }
-        $Uri = '{0}:{1}/{2}' -f "$($ssl['Protocol'])://$($Configuration['Hostname'])", $ssl['Port'], $Slug.TrimStart('/').TrimEnd('/')
-        $ApiHeader = if ($caller -notin $ApiKeyRequests -and $Configuration.Credential) {
-            @{'X-ApiKey' = $Configuration.Credential.GetNetworkCredential().Password }
-        } elseif ($Configuration.ApiKey) {
-            @{'X-ApiKey' = $Configuration.ApiKey.GetNetworkCredential().Password }
-        }
-
-        
         $params = @{
-            Uri                  = $Uri
+            Uri                  = "$($Configuration.EndpointUrl.TrimEnd('/'))/$($Slug.TrimStart('/'))"
             Method               = $Method
             ContentType          = $ContentType
-            Headers              = $ApiHeader
+            Headers              = @{
+                'X-ApiKey' = ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText
+            }
             Verbose              = $false
         }
 
-        if ((Get-Command Invoke-RestMethod).Parameters.SkipCertificateCheck) {
-            # We should probably remove this?
+        if ($env:PagootleIgnoreInvalidCertificate -and (Get-Command Invoke-RestMethod).Parameters.SkipCertificateCheck) {
             $params.SkipCertificateCheck = $true
         }
 
@@ -93,7 +76,7 @@ function Invoke-ProGet {
             }
         }
 
-        Write-Verbose "[$($Method.ToUpper())] $($Uri)"
+        Write-Verbose "[$($Method.ToUpper())] $($params.Uri)"
         Invoke-RestMethod @params
     }
 }

--- a/source/private/InvokeConfigMigration.ps1
+++ b/source/private/InvokeConfigMigration.ps1
@@ -1,0 +1,37 @@
+function InvokeConfigMigration {
+    param(
+        # The name of the configuration to migrate
+        [string]$Name,
+
+        # The version we're migrating to
+        [version]$Version
+    )
+    $OldConfig = Import-Configuration -CompanyName "Pagootle" -Name $Name
+
+    # Modify the configuration based on any updates made
+    switch ($Version) {
+        {$_ -gt '1.0.0'} {}
+        {$_ -gt '1.1.0'} {
+            # After version 1.1.0, we changed the default name and location for the configuration
+            $ConfigToLoad = @{
+                CompanyName = $env:USERNAME
+                Name = if ($Name -eq 'Default') {
+                    'ProGet'
+                } else {
+                    $Name
+                }
+            }
+
+            $OldConfig = Import-Configuration @ConfigToLoad
+
+            # We added an EndpointUrl value
+            $OldConfig.EndpointUrl= "http$(if ($OldConfig.UseSSL) {'s'})://$($OldConfig.HostName):$(@($OldConfig.NonSslPort, $OldConfig.SslPort)[$OldConfig.ContainsKey("UseSSL")])/"
+        }
+    }
+
+    # Update the "last updated" version
+    $OldConfig.ModuleVersion = (Get-Module Pagootle).Version
+
+    # Export the updated configuration to the config file
+    $OldConfig | Export-Configuration -CompanyName "Pagootle" -Name $Name
+}

--- a/source/private/InvokeConfigMigration.ps1
+++ b/source/private/InvokeConfigMigration.ps1
@@ -24,8 +24,27 @@ function InvokeConfigMigration {
 
             $OldConfig = Import-Configuration @ConfigToLoad
 
+            # We only use 'Port'
+            $OldConfig.Port = @($OldConfig.NonSslPort, $OldConfig.SslPort)[$OldConfig.ContainsKey("UseSSL")]
+            $null = $OldConfig.Remove("NonSslPort")
+            $null = $OldConfig.Remove("SslPort")
+
             # We added an EndpointUrl value
-            $OldConfig.EndpointUrl= "http$(if ($OldConfig.UseSSL) {'s'})://$($OldConfig.HostName):$(@($OldConfig.NonSslPort, $OldConfig.SslPort)[$OldConfig.ContainsKey("UseSSL")])/"
+            $OldConfig.EndpointUrl= "http$(if ($OldConfig.UseSSL) {'s'})://$($OldConfig.HostName):$($OldConfig.Port)/"
+
+            # We use a SecureString for storing the API Key
+            if ($OldConfig.ApiKey.Username) {
+                $OldConfig.ApiKey = $OldConfig.ApiKey.Password
+            }
+
+            # We no longer support Credential
+            if ($OldConfig.Credential -and -not $OldConfig.ApiKey) {
+                $OldConfig.ApiKey = CreateApiKeyFromCredential -Credential $Credential -Name $Name
+            }
+
+            if ($OldConfig.Credential) {
+                $null = $OldConfig.Remove("Credential")
+            }
         }
     }
 

--- a/source/public/Assets/Get-ProGetAssetDirectoryItem.ps1
+++ b/source/public/Assets/Get-ProGetAssetDirectoryItem.ps1
@@ -1,0 +1,71 @@
+function Get-ProGetAssetDirectoryItem {
+    <#
+    .SYNOPSIS
+    Returns the content of an asset directory on a feed.
+
+    .DESCRIPTION
+    Returns a list of files contained within a specified directory within a feed, on the currently available ProGet server.
+
+    .EXAMPLE
+    Get-ProGetAssetDirectoryItem -AssetDirectory Internal -Recurse
+
+    # Returns all items in the Internal asset directory.
+
+    .EXAMPLE
+    Get-ProGetAssetDirectoryItem -AssetDirectory Internal -Folder ops
+
+    # Returns all items in the ops folder of the Internal asset directory.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/folders/list
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Get-ProGetAssetDirectoryItem')]
+    [OutputType("ProGetAssetDirectoryItem")]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias("Parent")]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [string]
+        $Folder,
+
+        [switch]
+        $Recurse
+    )
+    process {
+        $RequestParams = @{
+            Slug = "/endpoints/$($AssetDirectory)/dir$(if($Folder){'/'})$($Folder.TrimStart('/').TrimEnd('/'))?recursive=$($Recurse)"
+        }
+
+        # ProGet returns an empty array if the path does not exist, or if there's nothing there.
+        [ProGetAssetDirectoryItem[]](Invoke-ProGet @RequestParams).Where{$_}
+    }
+}

--- a/source/public/Assets/Get-ProGetAssetItemMetadata.ps1
+++ b/source/public/Assets/Get-ProGetAssetItemMetadata.ps1
@@ -1,0 +1,61 @@
+function Get-ProGetAssetItemMetadata {
+    <#
+    .SYNOPSIS
+    Gets metadata from an asset.
+
+    .DESCRIPTION
+    Gets metadata from an asset, from the currently available ProGet server.
+
+    .EXAMPLE
+    Get-ProGetAssetItemMetadata -AssetDirectory -Path /some/file.txt
+
+    # Returns the asset metadata for the specified asset.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/metadata/get
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Get-ProGetAssetItemMetadata')]
+    [OutputType("ProGetAssetDirectoryItem")]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 1)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -ne 'dir' -and
+                $_.Content -like "*$($FakeBoundParameters.AssetDirectory)/content/*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')",
+                    "$($_.Name)",
+                    "ParameterValue",
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')"
+                )
+            }
+        })]
+        [string]
+        $Path
+    )
+    process {
+        $RequestParams = @{
+            Slug = "/endpoints/$AssetDirectory/metadata/$($Path.TrimStart('/'))"
+        }
+        
+        [ProGetAssetDirectoryItem[]](Invoke-ProGet @RequestParams).Where{$_} | Add-Member -TypeName "ProGetAssetItemMetadata" -PassThru
+    }
+}

--- a/source/public/Assets/Import-ProGetAssetDirectoryFromArchive.ps1
+++ b/source/public/Assets/Import-ProGetAssetDirectoryFromArchive.ps1
@@ -1,0 +1,72 @@
+function Import-ProGetAssetDirectoryFromArchive {
+    <#
+    .SYNOPSIS
+    Uploads an archive to a folder in an asset directory.
+
+    .DESCRIPTION
+    Uploads an archive to a folder in an asset directory on the currently active ProGet server.
+
+    .EXAMPLE
+    Import-ProGetAssetDirectoryFromArchive -AssetDirectory Internal -Folder /boinstall -ArchivePath ~\Downloads\boinstallfiles.zip -Overwrite
+
+    # Overwrites the current contents of the 'boinstall' folder with the contents of the boinstallfiles zip file.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/folders/import
+    #>
+    [CmdletBinding(SupportsShouldProcess, HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Import-ProGetAssetDirectoryFromArchive')]
+    param(
+        # The asset directory to upload to.
+        [Parameter(Mandatory)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset -Verbose:$false).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        # The folder to unpack the archive into.
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [string]
+        $Folder,
+
+        # The archive to upload.
+        [string]
+        $ArchivePath,
+
+        # If set, overwrites any existing files with the archive contents.
+        [switch]
+        $Overwrite
+    )
+    end {
+        $RequestParams = @{
+            Slug = "/endpoints/$($AssetDirectory)/import/$($Folder.TrimStart('/'))?format=$((Get-Item $ArchivePath).Extension.TrimStart('.'))&overwrite=$($Overwrite)"
+            Method = "POST"
+            File = Convert-Path $ArchivePath
+        }
+        if ($PSCmdlet.ShouldProcess("Uploading '$($ArchivePath | Split-Path -Leaf)' to $($AssetDirectory)/$($Folder.TrimStart('/'))")) {
+            $null = Invoke-ProGet @RequestParams
+        }
+    }
+}

--- a/source/public/Assets/New-ProGetAsset.ps1
+++ b/source/public/Assets/New-ProGetAsset.ps1
@@ -2,109 +2,178 @@ function New-ProGetAsset {
     <#
         .Synopsis
         Transfers a file to a ProGet asset directory.
-       
+
         .Description
         Transfers a file to a ProGet asset directory. This function performs automatic chunking
         if the file is larger than a specified threshold.
-       
-        .Parameter FileName
+
+        .Parameter Path
         Name of the file to upload from the local file system.
-        
-        .Parameter EndpointUrl
-        Full URL of the ProGet asset directory's API endpoint. This is typically something like http://proget/endpoints/<directoryname>
-        
+
+        .Parameter AssetDirectory
+        Name of the asset feed to upload the file to.
+
+        .Parameter Folder
+        Folder within the asset feed to store the file in.
+
         .Parameter AssetName
-        Full path of the asset to create in ProGet's asset directory.
-        
+        Name of the asset to create in ProGet's asset directory.
+
         .Parameter ChunkSize
-        Uploads larger than this value will be uploaded using multiple requests. The default is 5 MB.
-       
+        Uploads larger than 2GB will be uploaded using multiple requests of this size. The default is 5 MB. Uploading may be faster with larger chunk sizes!
+
+        .Parameter ForceMultipartUpload
+        Forces use of the multipart upload logic. If you're having a hard time uploading a large file, try this!
+
+        .Parameter Force
+        By default, the function will not upload if a file already exists with the expected name. Force overwrites existing files.
+
         .Example
-        New-ProGetAsset -FileName C:\Files\Image.jpg -AssetName images/image.jpg -EndpointUrl http://proget/endpoints/MyAssetDir
+        New-ProGetAsset -AssetDirectory -Path C:\Files\Image.jpg
+
+        .Link
+        https://docs.inedo.com/docs/proget/api/assets/files/upload
+
+        .Link
+        https://docs.inedo.com/docs/proget/api/assets/files/upload/multipart
     #>
     [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/New-ProGetAsset')]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory, ValueFromPipeline)]
         [string]
-        $fileName,
+        $Path,
 
-        [Parameter()]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
         [String]
         $AssetDirectory,
 
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [Alias("Parent")]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [string]
+        $Folder,
+
         [Parameter()]
         [string]
-        $Slug = '/endpoints/{0}' -f $AssetDirectory,
-
-        [Parameter(Mandatory = $true)]
-        [string]
-        $assetName,
+        $AssetName = $(Split-Path $Path -Leaf),
 
         [Parameter()]
-        [int]
-        $chunkSize = 5 * 1024 * 1024
+        [uint64]
+        $ChunkSize = 5MB,
+
+        [switch]
+        $Force,
+
+        [switch]
+        $ForceMultipartUpload
     )
-
     begin {
         $Configuration = Get-ProGetConfiguration
-
-        $ssl = if ($Configuration['UseSSL']) {
-            'https'
+        $ApiCredential = if ($Configuration.ApiKey) {
+            $Configuration.ApiKey.GetNetworkCredential().Password
+        } elseif ($Configuration.Credential) {
+            $Configuration.Credential.GetNetworkCredential().Password
         }
-        else {
-            'http'
-        }
-
     }
-
     process {
+        $fileInfo = Get-Item -Path $Path
 
-        $endpointUrl = "$($ssl)://$($Configuration['Hostname']):8443"
-        if (-not $endpointUrl.EndsWith('/')) { $endpointUrl += '/' }
-        $targetUrl = $endpointUrl + 'content/' + "$AssetDirectory/" + [Uri]::EscapeUriString($assetName.Replace('\', '/'))
-        Write-Verbose $targetUrl
-        $fileInfo = Get-ChildItem -Path $fileName
-
-        if ($fileInfo.Length -le $chunkSize) {
-            Invoke-WebRequest -Method Post -Uri $targetUrl -InFile $fileName
+        $RequestParams = @{
+            Slug = @(
+                "/endpoints"
+                $AssetDirectory
+                "content"
+                if ($Folder) {$Folder.TrimStart('/').TrimEnd('/')}
+                [Uri]::EscapeUriString($AssetName.Replace('\', '/'))
+            ) -join '/'
         }
-        else {
-            $sourceStream = [System.IO.FileStream]::new($fileName, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read, 4096, [System.IO.FileOptions]::SequentialScan)
+
+        if (-not $ForceMultipartUpload -and $fileInfo.Length -lt 2GB) {
+            $RequestParams += @{
+                Method = if ($Force) {"Post"} else {"Put"}
+                File = $FileInfo.FullName
+            }
+            try {
+                $null = Invoke-ProGet @RequestParams
+            } catch {
+                if ($_.Exception.Response.StatusCode -eq 400) {
+                    Write-Error -Message "$_ Run with -Force to overwrite!" -Exception $_.Exception -ErrorAction Stop
+                }
+                throw
+            }
+        } else {  # The Multipart Asset File Upload is an HTTP Request specifically for multipart uploads of very large (2GB+) files.
+            # As this endpoint doesn't complain if we overwrite a file, check if we aren't forcing upload.
+            if (-not $Force -and (Invoke-ProGet @RequestParams)) {
+                Write-Error -Message "The specified asset already exists. Run with -Force to overwrite!" -Category InvalidOperation -ErrorAction Stop 
+            }
+
+            $sourceStream = [System.IO.FileStream]::new($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read, 4096, [System.IO.FileOptions]::SequentialScan)
 
             try {
                 $fileLength = $sourceStream.Length
-                $remainder = 0
-                $totalParts = [Math]::DivRem($fileLength, $chunkSize, [ref]$remainder)
-                if ($remainder -ne 0) { $totalParts++ }
-                $uuid = [Guid]::NewGuid().ToString("N")
+                $remainder = [long]0
+                $totalParts = [Math]::DivRem([long]$fileLength, [long]$chunkSize, [ref]$remainder)
+                if($remainder -ne 0) { $totalParts++ }
+                $uuid = (New-Guid).ToString("N")
 
-                0..($totalParts - 1) | ForEach-Object {
+                0..($totalParts-1) | ForEach-Object {
                     $index = $_
                     $offset = $index * $chunkSize
                     $currentChunkSize = if ($index -eq ($totalParts - 1)) { $fileLength - $offset } else { $chunkSize }
 
-                    $req = [System.Net.WebRequest]::CreateHttp("${targetUrl}?multipart=upload&id=$uuid&index=$index&offset=$offset&totalSize=$fileLength&partSize=$currentChunkSize&totalParts=$totalParts")
+                    $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=upload&id=$uuid&index=$index&offset=$offset&totalSize=$fileLength&partSize=$currentChunkSize&totalParts=$totalParts")
                     $req.Method = 'POST'
+                    Write-Verbose "[$($req.Method)] $($req.RequestUri)"
+                    $req.Headers.Add("X-ApiKey", $ApiCredential)
                     $req.ContentLength = $currentChunkSize
                     $req.AllowWriteStreamBuffering = $false
                     $reqStream = $req.GetRequestStream()
-
                     try { CopyMaxBytes -source $sourceStream -target $reqStream -maxBytes $currentChunkSize -startOffset $offset -totalSize $fileLength }
-                    finally { if ($reqStream) { $reqStream.Dispose() } }
+                    finally { if($reqStream) { $reqStream.Dispose() } }
 
-                    $response = $req.GetResponse()
-                    try { } finally { if ($response) { $response.Dispose() } }
+                    try {
+                        $response = $req.GetResponse()
+                    } finally { if($response) { $response.Dispose() } }
                 }
 
-                Write-Progress -Activity "Uploading $fileName..." -Status "Completing upload..." -PercentComplete -1
+                Write-Progress -Activity "Uploading $Path..." -Status "Completing upload..." -PercentComplete -1
 
-                $req = [System.Net.WebRequest]::CreateHttp("${targetUrl}?multipart=complete&id=$uuid")
+                Write-Verbose "Completing Multipart Upload of '$($Path)'"
+                $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=complete&id=$uuid")
                 $req.Method = 'POST'
+                Write-Verbose "[$($req.Method)] $($req.RequestUri)"
+                $req.Headers.Add("X-ApiKey", $ApiCredential)
                 $req.ContentLength = 0
-                $response = $req.GetResponse()
-                try { } finally { if ($response) { $response.Dispose() } }
+                try {
+                    $response = $req.GetResponse()
+                } finally { if($response) { $response.Dispose() } }
             }
-            finally { if ($sourceStream) { $sourceStream.Dispose() } }
+            finally { if($sourceStream) { $sourceStream.Dispose() } }
         }
     }
 }

--- a/source/public/Assets/New-ProGetAsset.ps1
+++ b/source/public/Assets/New-ProGetAsset.ps1
@@ -94,11 +94,6 @@ function New-ProGetAsset {
     )
     begin {
         $Configuration = Get-ProGetConfiguration
-        $ApiCredential = if ($Configuration.ApiKey) {
-            $Configuration.ApiKey.GetNetworkCredential().Password
-        } elseif ($Configuration.Credential) {
-            $Configuration.Credential.GetNetworkCredential().Password
-        }
     }
     process {
         $fileInfo = Get-Item -Path $Path
@@ -149,7 +144,7 @@ function New-ProGetAsset {
                     $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=upload&id=$uuid&index=$index&offset=$offset&totalSize=$fileLength&partSize=$currentChunkSize&totalParts=$totalParts")
                     $req.Method = 'POST'
                     Write-Verbose "[$($req.Method)] $($req.RequestUri)"
-                    $req.Headers.Add("X-ApiKey", $ApiCredential)
+                    $req.Headers.Add("X-ApiKey", (ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText))
                     $req.ContentLength = $currentChunkSize
                     $req.AllowWriteStreamBuffering = $false
                     $reqStream = $req.GetRequestStream()
@@ -167,7 +162,7 @@ function New-ProGetAsset {
                 $req = [System.Net.WebRequest]::CreateHttp("$($Configuration.EndpointUrl)$($RequestParams.Slug)?multipart=complete&id=$uuid")
                 $req.Method = 'POST'
                 Write-Verbose "[$($req.Method)] $($req.RequestUri)"
-                $req.Headers.Add("X-ApiKey", $ApiCredential)
+                $req.Headers.Add("X-ApiKey", (ConvertFrom-SecureString $Configuration.ApiKey -AsPlainText))
                 $req.ContentLength = 0
                 try {
                     $response = $req.GetResponse()

--- a/source/public/Assets/New-ProGetAssetDirectory.ps1
+++ b/source/public/Assets/New-ProGetAssetDirectory.ps1
@@ -1,0 +1,72 @@
+function New-ProGetAssetDirectory {
+    <#
+    .SYNOPSIS
+    Creates an directory.
+
+    .DESCRIPTION
+    Creates an directory in a specified asset directory feed, on the currently active ProGet server.
+
+    .EXAMPLE
+    New-ProGetAssetDirectory -AssetDirectory Internal -Path /some/path
+
+    # Creates the specified directory.
+
+    .EXAMPLE
+    $Directories = Get-ProGetAssetDirectory -AssetDirectory Internal | Where type -eq 'dir'
+    Set-ProGetConfiguration -Hostname Otherhost -Apikey $ApiKey
+    New-ProGetFeed -Name 'Internal' -Type asset -Active
+    $Directories | New-ProGetAssetDirectory
+
+    # Recreate the directories you have on an existing server on a new asset directory.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/folders/create
+    #>
+    [CmdletBinding(SupportsShouldProcess, HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/New-ProGetAssetDirectory')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 1)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')/".TrimStart('/'),
+                    $_.Name,
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')/".TrimStart('/')
+                )
+            }
+        })]
+        [Alias("Parent")]
+        [string]
+        $Path
+    )
+    process {
+        $RequestParams = @{
+            Slug = "/endpoints/$($AssetDirectory)/dir/$($Path.TrimStart('/'))"
+            Method = "Post"
+        }
+
+        if ($PSCmdlet.ShouldProcess($Path, "Creating Directory in AssetDirectory '$AssetDirectory'")) {
+            $null = Invoke-ProGet @RequestParams
+        }
+    }
+}

--- a/source/public/Assets/Remove-ProGetAssetDirectory.ps1
+++ b/source/public/Assets/Remove-ProGetAssetDirectory.ps1
@@ -1,0 +1,77 @@
+function Remove-ProGetAssetDirectory {
+    <#
+    .SYNOPSIS
+    Removes a folder on an asset directory feed.
+
+    .DESCRIPTION
+    Removes a folder within an asset directory feed, on the currently available ProGet server.
+
+    .EXAMPLE
+    Remove-ProGetAssetDirectory -AssetDirectory Internal -Folder oldfiles
+
+    # Removes the specified directory.
+
+    .EXAMPLE
+    Remove-ProGetAssetDirectory -AssetDirectory Internal -Folder some/files -Recurse -Confirm:$false
+
+    # Recursively remove everything in the specified directory.
+
+    .EXAMPLE
+    Get-ProGetAssetDirectoryItem | Where-Object {$_.Name -eq v1.03 -and $_.Type -eq 'dir'} | Remove-ProGetAssetDirectory -Recurse -Confirm:$false
+
+    # Removes piped in folders recursively.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/folders/delete
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Remove-ProGetAssetDirectory')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 1)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    $_.Name,
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [Alias("Parent")]
+        [string]
+        $Folder,
+
+        [switch]
+        $Recurse
+    )
+    process {
+        $RequestParams = @{
+            Slug = "/endpoints/$($AssetDirectory)/delete/$($Folder.TrimStart('/').TrimEnd('/'))?recursive=$($Recurse)"
+            Method = "Post"
+        }
+
+        if ($PSCmdlet.ShouldProcess($RequestParams.Slug, "Removing Folder$(if ($Recurse) {' and children'}) from AssetDirectory")) {
+            $null = Invoke-ProGet @RequestParams
+        }
+    }
+}

--- a/source/public/Assets/Remove-ProGetAssetDirectoryItem.ps1
+++ b/source/public/Assets/Remove-ProGetAssetDirectoryItem.ps1
@@ -1,0 +1,72 @@
+function Remove-ProGetAssetDirectoryItem {
+    <#
+    .SYNOPSIS
+    Removes an asset on an asset directory feed.
+
+    .DESCRIPTION
+    Removes an asset within an asset directory feed, on the currently available ProGet server.
+
+    .EXAMPLE
+    Remove-ProGetAssetDirectoryItem -AssetDirectory Internal -Path old-file.txt
+
+    # Removes the specified file.
+
+    .EXAMPLE
+    Get-ProGetAssetDirectoryItem -AssetDirectory Internal | Where-Object Modified -lt (Get-Date).AddYears(-1) | Remove-ProGetAssetDirectoryItem -Confirm:$false
+
+    # Removes assets that haven't been modified in a year.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/files/delete
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Remove-ProGetAssetDirectoryItem', DefaultParameterSetName = "Pipeline")]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0, ParameterSetName = "Split")]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 1, ParameterSetName = "Split")]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -ne 'dir' -and
+                $_.Content -like "*$($FakeBoundParameters.AssetDirectory)/content/*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')",
+                    "$($_.Name)",
+                    "ParameterValue",
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')"
+                )
+            }
+        })]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = "Pipeline")]
+        [string]
+        $Content = "/endpoints/$($AssetDirectory)/content/$($Path.TrimStart('/').TrimEnd('/'))"
+    )
+    process {
+        $RequestParams = @{
+            Slug = $Content -replace ".*(?<Slug>/endpoints/(?<AssetDirectory>.+?)/content/(?<Path>.+?))$", '${Slug}'
+            Method = "Delete"
+        }
+
+        if ($PSCmdlet.ShouldProcess($Slug, "Removing Asset from AssetDirectory")) {
+            $null = Invoke-ProGet @RequestParams
+        }
+    }
+}

--- a/source/public/Assets/Save-ProGetAsset.ps1
+++ b/source/public/Assets/Save-ProGetAsset.ps1
@@ -1,0 +1,105 @@
+function Save-ProGetAsset {
+    <#
+    .SYNOPSIS
+    Saves a ProGet asset to disk.
+
+    .DESCRIPTION
+    Saves a file from a ProGet asset feed (on the currently available ProGet server) to the local machine.
+
+    .EXAMPLE
+    Save-ProGetAsset -AssetDirectory Internal -Path /some/folder/file.txt
+
+    .EXAMPLE
+    Get-ProGetAssetDirectoryItem -AssetDirectory Internal -Parent bob | Where Type -ne dir | Save-ProGetAsset
+
+    .EXAMPLE
+    Save-ProGetAsset -AssetDirectory Internal -Parent some/folder -Name file.txt -OutputPath c:\temp\downloads
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/files/download
+    #>
+    [CmdletBinding(DefaultParameterSetName = "SplitFile", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Save-ProGetAsset')]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset -Verbose:$false).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        [Parameter(ParameterSetName = "Path", Mandatory)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Folder $FakeBoundParameters.Folder -Recurse | Where-Object {
+                $_.Type -ne 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [string]
+        $Path,
+
+        [Parameter(ParameterSetName = "SplitFile", ValueFromPipelineByPropertyName)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [Alias("Folder")]
+        [string]
+        $Parent,
+
+        [Parameter(ParameterSetName = "SplitFile", Mandatory, ValueFromPipelineByPropertyName)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Folder $FakeBoundParameters.Parent -Recurse | Where-Object {
+                $_.Type -ne 'dir' -and
+                $_.Name -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    $_.Name,
+                    $_.Name,
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $OutputPath = $PWD.Path
+    )
+    process {
+        if ($PSCmdlet.ParameterSetName -ne 'Path') {
+            $Path = $Parent, $Name -join '/'
+        }
+        "endpoints/$($AssetDirectory)/content/$($Path.TrimStart('/'))" | DownloadProGetFile -OutputPath $OutputPath -PassThru
+    }
+}

--- a/source/public/Assets/Save-ProGetAssetDirectoryArchive.ps1
+++ b/source/public/Assets/Save-ProGetAssetDirectoryArchive.ps1
@@ -1,0 +1,77 @@
+function Save-ProGetAssetDirectoryArchive {
+    <#
+    .SYNOPSIS
+    Saves a ProGet asset folder to disk as an archive.
+
+    .DESCRIPTION
+    Saves a folder from a ProGet asset feed (on the currently available ProGet server) to the local machine.
+
+    .EXAMPLE
+    Save-ProGetAsset -AssetDirectory Internal -Path /some/folder
+
+    .EXAMPLE
+    Save-ProGetAsset -AssetDirectory Internal -Parent some/folder -OutputPath c:\temp\downloads\folder.zip
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/files/download
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Save-ProGetAssetDirectory')]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        # The asset directory to download the folder from.
+        [Parameter(Mandatory)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset -Verbose:$false).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        # The folder to download.
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -eq 'dir' -and
+                "$($_.Parent, $_.Name -join '/')".TrimStart('/') -like "*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/'),
+                    "ParameterValue",
+                    "$($_.Parent, $_.Name -join '/')".TrimStart('/')
+                )
+            }
+        })]
+        [Alias('Path')]
+        [string]
+        $Folder,
+
+        # If selected, downloads nested levels within the folder - otherwise just downloads the top level.
+        [switch]
+        $Recurse,
+
+        # The path to output the file to.
+        [string]
+        $OutputPath = $PWD.Path,
+
+        # The format to download - supports zip or tgz.
+        [ValidateSet("zip", "tgz")]
+        [string]
+        $Format = "zip"
+    )
+    end {
+        $Result = "/endpoints/$($AssetDirectory)/export/$($Folder)?format=$($Format)&recursive=$($Recurse)" | DownloadProGetFile -OutputPath $OutputPath -PassThru
+
+        if (-not $Result.extension) {
+            $Result | Rename-Item -NewName {$_.Name + '.' + $Format} -PassThru
+        }
+    }
+}

--- a/source/public/Assets/Set-ProGetAssetItemMetadata.ps1
+++ b/source/public/Assets/Set-ProGetAssetItemMetadata.ps1
@@ -1,0 +1,116 @@
+function Set-ProGetAssetItemMetadata {
+    <#
+    .SYNOPSIS
+    Sets metadata for an asset.
+
+    .DESCRIPTION
+    Sets metadata for an asset, on the currently available ProGet server.
+
+    .EXAMPLE
+    Set-ProGetAssetItemMetadata -AssetDirectory Internal -Path /some/file.txt -UserMetadata @{myKey = 'myValue'}
+
+    # Adds to the metadata of the existing asset.
+
+    .EXAMPLE
+    Set-ProGetAssetItemMetadata -AssetDirectory Internal -Path /some/file.txt -UserMetadata @{myKey = 'myValue'} -UserMetadataUpdateMode 'Replace'
+
+    # Overwrites the metadata of the existing asset.
+
+    .EXAMPLE
+    Set-ProGetAssetItemMetadata -AssetDirectory Internal -Path /some/file.txt -CacheHeader @{type = 'TTL'; value = '60'}
+
+    # Modifies the cache header assigned to the asset.
+
+    .EXAMPLE
+    Set-ProGetAssetItemMetadata -AssetDirectory Internal -Path /some/file.txt -CacheHeader @{type = 'Inherit'}
+
+    # Modifies the cache header assigned to the asset.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/assets/metadata/set
+
+    .LINK
+    https://github.com/Inedo/pgutil/blob/thousand/Inedo.ProGet/AssetDirectories/AssetItemMetadataUpdate.cs
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Commands/Set-ProGetAssetItemMetadata')]
+    param(
+        # The asset directory within which the asset to modify is contained.
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed -Type asset).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed -Type asset | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $AssetDirectory,
+
+        # The path to asset to modify.
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 1)]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetAssetDirectoryItem -AssetDirectory $FakeBoundParameters.AssetDirectory -Recurse | Where-Object {
+                $_.Type -ne 'dir' -and
+                $_.Content -like "*$($FakeBoundParameters.AssetDirectory)/content/*$WordToComplete*"
+            } | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new(
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')",
+                    "$($_.Name)",
+                    "ParameterValue",
+                    "$($_.Content -replace ".+/endpoints/$($FakeBoundParameters.AssetDirectory)/content/(?<Path>.+)$", '${Path}')"
+                )
+            }
+        })]
+        [string]
+        $Path,
+
+        # The Content-Type assigned to the object, e.g. image/jpeg
+        [string]$Type,
+
+        # Additional user metadata to store and return on the object.
+        [Parameter(Mandatory, ParameterSetName = 'User')]
+        [hashtable]$UserMetadata,
+
+        # Whether to merge (update) the user metadata, or overwrite it entirely (replace).
+        [Parameter(ParameterSetName = 'User')]
+        [ValidateSet("Update", "Replace")]
+        $UserMetadataUpdateMode = "Update",
+
+        # Cache headers returned with the object to influence external caching, e.g. @{type='TTL';value=60}, @{type='Inherit'} etc.
+        [Parameter(Mandatory, ParameterSetName = 'Cache')]
+        [ValidateScript({
+            # https://github.com/Inedo/pgutil/blob/thousand/Inedo.ProGet/AssetDirectories/AssetDirectoryItemCacheHeader.cs
+            if ($false -notin $_.Keys.ForEach{$_ -notin @('Type', 'Value')}) {throw "CacheHeader must only contain 'Type' and (optionally) 'Value'"}
+            if (-not $_.Type) {throw "CacheHeader must contain a Type"}
+            $true
+        })]
+        [hashtable]$CacheHeader
+    )
+    process {
+        $RequestParams = @{
+            Slug = "/endpoints/$AssetDirectory/metadata/$Path"
+            Method = "Post"
+            Body = @{
+                type = $type
+                userMetadataUpdateMode = $UserMetadataUpdateMode.ToLower()
+            }
+        }
+
+        switch ($PSCmdlet.ParameterSetName) {
+            "Cache" {
+                $RequestParams.Body.cacheHeader = $CacheHeader
+            }
+            "User" {
+                $RequestParams.Body.userMetadata = $UserMetadata
+            }
+        }
+
+        $null = Invoke-ProGet @RequestParams
+    }
+}

--- a/source/public/Feeds/Get-ProGetFeed.ps1
+++ b/source/public/Feeds/Get-ProGetFeed.ps1
@@ -31,21 +31,19 @@ function Get-ProGetFeed {
     .NOTES
 
     #>
-    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Get-ProGetFeed')]
-    Param(
-        [Parameter()]
+    [CmdletBinding(DefaultParameterSetName = "Feed", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Get-ProGetFeed')]
+    param(
+        [Parameter(ParameterSetName = "Feed")]
+        [Alias("Name")]
         [String]
         $Feed,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = "Type")]
         [ValidateSet('asset', 'bower', 'conda', 'chocolatey', 'debianlegacy', 'debian', 'docker', 'helm', 'maven', 'npm', 'nuget', 'powershell', 'universal', 'pypi', 'romp', 'rpm', 'rubygems', 'vsix')]
         [String]
         $Type
     )
     end {
-        if($Feed -and $Type){
-            throw 'Only one parameter of Feed or Type can be used at a time'
-        }
         $params = @{
             Method = 'GET'
         }

--- a/source/public/Feeds/New-ProGetFeed.ps1
+++ b/source/public/Feeds/New-ProGetFeed.ps1
@@ -88,7 +88,8 @@ function New-ProGetFeed {
         $AlternateNames,
 
         [Parameter()]
-        [ValidateSet('asset', 'bower', 'conda', 'chocolatey', 'debianlegacy', 'debian', 'docker', 'helm', 'maven', 'npm', 'nuget', 'powershell', 'universal', 'pypi', 'romp', 'rpm', 'rubygems', 'vsix')]        [String]
+        [ValidateSet('asset', 'bower', 'conda', 'chocolatey', 'debianlegacy', 'debian', 'docker', 'helm', 'maven', 'npm', 'nuget', 'powershell', 'universal', 'pypi', 'romp', 'rpm', 'rubygems', 'vsix')]
+        [String]
         $Type = 'NuGet',
 
         [Parameter()]

--- a/source/public/ModuleConfiguration/Get-ProGetConfiguration.ps1
+++ b/source/public/ModuleConfiguration/Get-ProGetConfiguration.ps1
@@ -7,7 +7,7 @@ function Get-ProGetConfiguration {
     The `Get-ProGetConfiguration` function retrieves the configuration for ProGet. By default, it retrieves the configuration for ProGet unless a different configuration name is provided.
 
     .PARAMETER Configuration
-    The name of the configuration to retrieve. Defaults to 'ProGet'.
+    The name of the configuration to retrieve. Defaults to 'Default'.
 
     .EXAMPLE
     Get-ProGetConfiguration
@@ -17,17 +17,24 @@ function Get-ProGetConfiguration {
     .EXAMPLE
     Get-ProGetConfiguration -Configuration "CustomConfig"
 
-    Retrieves the configuration for the configuration named "CustomConfige".
+    Retrieves the configuration for the configuration named "CustomConfig".
 #>
     [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Get-ProGetConfiguration')]
     Param(
         [Parameter()]
         [Alias('Name')]
         [String]
-        $Configuration = 'ProGet'
+        $Configuration = $script:CurrentConfiguration
     )
     end {
-        Import-Configuration -CompanyName $env:USERNAME -Name $Configuration
-    }
+        $Config = Import-Configuration -CompanyName "Pagootle" -Name $Configuration
 
+        if ($Config.ModuleVersion -lt (Get-Module Pagootle).Version) {
+            Write-Verbose "Migrating configuration from '$($Config.ModuleVersion)' to '$((Get-Module Pagootle).Version)'"
+            InvokeConfigMigration -Name $Configuration -Version (Get-Module Pagootle).Version
+            $Config = Import-Configuration -CompanyName "Pagootle" -Name $Configuration
+        }
+
+        $Config
+    }
 }

--- a/source/public/ModuleConfiguration/Set-ProGetConfiguration.ps1
+++ b/source/public/ModuleConfiguration/Set-ProGetConfiguration.ps1
@@ -10,27 +10,24 @@ function Set-ProGetConfiguration {
     The hostname of the ProGet server. This parameter is mandatory.
 
     .PARAMETER Credential
-    A PSCredential object containing the username and password for authenticating with the ProGet server. This parameter is mandatory.
+    A PSCredential object containing the username and password for authenticating with the ProGet server. If provided, we create an API key for you, and store that.
 
-    .PARAMETER NonSslPort
-    The port to use for non-SSL connections. Defaults to 8624.
+    .PARAMETER Port
+    The port to use.
 
     .PARAMETER UseSSL
-    Specifies whether to use SSL for the connection. This parameter is part of the 'ssl' parameter set.
-
-    .PARAMETER SslPort
-    The port to use for SSL connections. Defaults to 443. This parameter is mandatory when `UseSSL` is specified.
+    Specifies whether to use SSL for the connection.
 
     .PARAMETER Name
     The name of the configuration to save. Defaults to 'Default'.
 
     .PARAMETER ApiKey
-    The API key to use for authentication. Defaults to 'SetMe'.
+    The API key to use for authentication.
 
     .EXAMPLE
-    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential (Get-Credential)
+    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential admin
 
-    Sets the configuration for ProGet with the specified hostname and credentials.
+    Sets the configuration for ProGet with the specified hostname and a created API key.
 
     .EXAMPLE
     Set-ProGetConfiguration -Hostname "proget.example.com" -ApiKey asdf8675309
@@ -38,17 +35,12 @@ function Set-ProGetConfiguration {
     Sets the configuration for ProGet with the specified hostname and apikey
 
     .EXAMPLE
-    Set-ProGetConfiguration -Hostname "proget.example.com" -ApiKey asdf8675309 -Credential (Get-Credential)
-
-    Sets the configuration for ProGet with the specified hostname, credential, and apikey
-
-    .EXAMPLE
-    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential (Get-Credential) -UseSSL -SslPort 8443
+    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential admin -UseSSL -Port 8443
 
     Sets the configuration for ProGet with SSL enabled and a custom SSL port.
 
     .EXAMPLE
-    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential (Get-Credential) -Name "CustomConfig"
+    Set-ProGetConfiguration -Hostname "proget.example.com" -Credential admin -Name "CustomConfig"
 
     Sets the configuration for ProGet with a custom configuration name.
     #>
@@ -59,26 +51,20 @@ function Set-ProGetConfiguration {
         $Hostname,
 
         [Parameter(Mandatory, ParameterSetName = 'Credential')]
-        [Parameter(Mandatory, ParameterSetName = 'Both')]
         [System.Management.Automation.PSCredential]
         $Credential,
 
         [Parameter(Mandatory, ParameterSetName = 'Apikey')]
-        [Parameter(Mandatory, ParameterSetName = 'Both')]
         [String]
         $ApiKey,
 
         [Parameter()]
-        [Int]
-        $NonSslPort = '8624',
+        [UInt16]
+        $Port = $(if ($UseSSL) {443} else {8624}),
 
         [Parameter()]
         [Switch]
         $UseSSL,
-
-        [Parameter()]
-        [Int]
-        $SslPort = 443,
 
         [Parameter()]
         [String]
@@ -88,25 +74,20 @@ function Set-ProGetConfiguration {
         $Configuration = @{
             ModuleVersion = (Get-Module Pagootle).Version
             Hostname      = $Hostname
-            NonSslPort    = $NonSslPort
+            Port          = [string]$Port
         }
 
-        if ($UseSSL) {
-            $Configuration.Add('UseSSL', $UseSSL)
-            $Configuration.Add('SSLPort', $SslPort)
-        }
+        $Configuration.Add('EndpointUrl', "http$(if ($UseSSL) {'s'})://$($HostName):$($Port)/")
 
         switch ($PSBoundParameters.Keys) {
             'Credential' {
-                $Configuration.Add('Credential', $Credential)
+                $Configuration.ApiKey = CreateApiKeyFromCredential -Credential $Credential -Name $Name
             }
             'ApiKey' {
-                $Configuration.Add('ApiKey', $([PSCredential]::new('null', ($ApiKey | ConvertTo-SecureString -AsPlainText -Force))))
+                $Configuration.Add('ApiKey', (ConvertTo-SecureString $ApiKey -AsPlainText -Force))
             }
         }
 
-        $Configuration.Add('EndpointUrl', "http$(if ($UseSSL) {'s'})://$($HostName):$(@($NonSslPort, $SslPort)[$UseSSL])/")
-        
-        $Configuration | Export-Configuration -CompanyName $env:USERNAME -Name $Name -Scope User
+        $Configuration | Export-Configuration -CompanyName "Pagootle" -Name $Name
     }
 }

--- a/source/public/ModuleConfiguration/Set-ProGetConfiguration.ps1
+++ b/source/public/ModuleConfiguration/Set-ProGetConfiguration.ps1
@@ -22,7 +22,7 @@ function Set-ProGetConfiguration {
     The port to use for SSL connections. Defaults to 443. This parameter is mandatory when `UseSSL` is specified.
 
     .PARAMETER Name
-    The name of the configuration to save. Defaults to 'ProGet'.
+    The name of the configuration to save. Defaults to 'Default'.
 
     .PARAMETER ApiKey
     The API key to use for authentication. Defaults to 'SetMe'.
@@ -51,9 +51,9 @@ function Set-ProGetConfiguration {
     Set-ProGetConfiguration -Hostname "proget.example.com" -Credential (Get-Credential) -Name "CustomConfig"
 
     Sets the configuration for ProGet with a custom configuration name.
-#>
+    #>
     [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Set-ProGetConfiguration' , DefaultParameterSetName = 'Apikey')]
-    Param(
+    param(
         [Parameter(Mandatory)]
         [String]
         $Hostname,
@@ -62,7 +62,12 @@ function Set-ProGetConfiguration {
         [Parameter(Mandatory, ParameterSetName = 'Both')]
         [System.Management.Automation.PSCredential]
         $Credential,
-        
+
+        [Parameter(Mandatory, ParameterSetName = 'Apikey')]
+        [Parameter(Mandatory, ParameterSetName = 'Both')]
+        [String]
+        $ApiKey,
+
         [Parameter()]
         [Int]
         $NonSslPort = '8624',
@@ -77,18 +82,13 @@ function Set-ProGetConfiguration {
 
         [Parameter()]
         [String]
-        $Name = 'ProGet',
-
-        [Parameter(Mandatory, ParameterSetName = 'Apikey')]
-        [Parameter(Mandatory, ParameterSetName = 'Both')]
-        [String]
-        $ApiKey
+        $Name = $script:CurrentConfiguration
     )
-
     end {
         $Configuration = @{
-            Hostname   = $Hostname
-            NonSslPort = $NonSslPort
+            ModuleVersion = (Get-Module Pagootle).Version
+            Hostname      = $Hostname
+            NonSslPort    = $NonSslPort
         }
 
         if ($UseSSL) {
@@ -96,25 +96,16 @@ function Set-ProGetConfiguration {
             $Configuration.Add('SSLPort', $SslPort)
         }
 
-        switch ($PSCmdlet.ParameterSetName) {
-            
+        switch ($PSBoundParameters.Keys) {
             'Credential' {
                 $Configuration.Add('Credential', $Credential)
             }
-
             'ApiKey' {
                 $Configuration.Add('ApiKey', $([PSCredential]::new('null', ($ApiKey | ConvertTo-SecureString -AsPlainText -Force))))
             }
-
-            'Both' {
-                if (-not $Credential -or -not $ApiKey) {
-                    throw "Both Credential and ApiKey must be provided when using the 'Both' parameter set."
-                }
-                
-                $Configuration.Add('Credential', $Credential)
-                $Configuration.Add('ApiKey', $([PSCredential]::new('null', ($ApiKey | ConvertTo-SecureString -AsPlainText -Force))))
-            }
         }
+
+        $Configuration.Add('EndpointUrl', "http$(if ($UseSSL) {'s'})://$($HostName):$(@($NonSslPort, $SslPort)[$UseSSL])/")
         
         $Configuration | Export-Configuration -CompanyName $env:USERNAME -Name $Name -Scope User
     }

--- a/source/public/ModuleConfiguration/Switch-ProGetConfiguration.ps1
+++ b/source/public/ModuleConfiguration/Switch-ProGetConfiguration.ps1
@@ -1,0 +1,27 @@
+function Switch-ProGetConfiguration {
+    <#
+    .SYNOPSIS
+    Sets the configuration profile to load when calling Pagootle functions.
+
+    .DESCRIPTION
+    Sets a script-level value to the configuration profile used by the functions.
+    
+    .EXAMPLE
+    Switch-ProGetConfiguration ProdServer3
+
+    # Future cmdlets will poll the server defined in the ProdServer3 configuration.
+
+    .EXAMPLE
+    Switch-ProGetConfiguration
+
+    # Sets the configuration back to the default, non-specifically named config.
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Switch-ProGetConfiguration')]
+    param(
+        [Parameter(Position = 0)]
+        [Alias('Name')]
+        [string]
+        $Configuration = "Default"
+    )
+    $script:CurrentConfiguration = $Configuration
+}

--- a/source/public/Security/ApiKeys/Get-ProGetApiKey.ps1
+++ b/source/public/Security/ApiKeys/Get-ProGetApiKey.ps1
@@ -21,6 +21,7 @@ function Get-ProGetApiKey {
         https://docs.inedo.com/docs/proget/api/apikeys/list
     #>
     [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Get-ProGetApiKey')]
+    [OutputType("ProGetApiKey")]
     param(
         # The name of the user to return keys for.
         [Parameter(ValueFromPipeline)]
@@ -31,7 +32,7 @@ function Get-ProGetApiKey {
         $RequestParams = @{
             Slug = '/api/api-keys/list'
         }
-        $Result = Invoke-ProGet @RequestParams
+        [ProGetApiKey[]]$Result = Invoke-ProGet @RequestParams
     }
     process {
         if ($User) {

--- a/source/public/Security/ApiKeys/Get-ProGetApiKey.ps1
+++ b/source/public/Security/ApiKeys/Get-ProGetApiKey.ps1
@@ -1,0 +1,43 @@
+function Get-ProGetApiKey {
+    <#
+        .SYNOPSIS
+        Returns a list of API keys.
+
+        .DESCRIPTION
+        Returns a list of API keys for the currently available ProGet server.
+        These can be filtered by source and authentication.
+
+        .EXAMPLE
+        Get-ProGetApiKey
+
+        # Returns all existing API keys.
+
+        .EXAMPLE
+        Get-ProGetApiKey -User "bob"
+
+        # Returns all API keys for user 'bob'.
+
+        .LINK
+        https://docs.inedo.com/docs/proget/api/apikeys/list
+    #>
+    [CmdletBinding(HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Get-ProGetApiKey')]
+    param(
+        # The name of the user to return keys for.
+        [Parameter(ValueFromPipeline)]
+        [string[]]
+        $User
+    )
+    begin {
+        $RequestParams = @{
+            Slug = '/api/api-keys/list'
+        }
+        $Result = Invoke-ProGet @RequestParams
+    }
+    process {
+        if ($User) {
+            $Result.Where{$_.User -in $User}
+        } else {
+            $Result
+        }
+    }
+}

--- a/source/public/Security/ApiKeys/New-ProGetApiKey.ps1
+++ b/source/public/Security/ApiKeys/New-ProGetApiKey.ps1
@@ -92,7 +92,7 @@ function New-ProGetApiKey {
             Slug   = "/api/api-keys/create"
             Method = "Post"
             Body   = @{
-                type               = $PSCmdlet.ParameterSetName.ToLower()
+                type               = $PSCmdlet.ParameterSetName.ToLower() -replace "^feedgroup$","feed"
                 displayName        = $DisplayName
                 description        = $Description
                 expiration         = if ($Expiration) {$Expiration.ToUniversalTime()} else {$null}

--- a/source/public/Security/ApiKeys/New-ProGetApiKey.ps1
+++ b/source/public/Security/ApiKeys/New-ProGetApiKey.ps1
@@ -1,0 +1,129 @@
+function New-ProGetApiKey {
+    <#
+    .SYNOPSIS
+    Creates an API key.
+
+    .DESCRIPTION
+    Creates an API key on the currently available ProGet server.
+
+    .EXAMPLE
+    New-ProGetApiKey -DisplayName Test -Description 'A test key' -SystemApi full_control
+
+    # Creates a test system level API key with full control.
+
+    .EXAMPLE
+    New-ProGetApiKey -DisplayName PackagePusher -Description 'Key for pushing packages' -FeedGroup Chocolatey -PackagePermissions view,add
+
+    # Creates a feedgroup level API key with permission to view, download, and push packages.
+
+    .EXAMPLE
+    New-ProGetApiKey -DisplayName PackagePusher -Description 'Key for pushing packages' -Feed ChocolateyInternal -PackagePermissions view
+
+    # Creates a feed level API key with permission to view and download packages.
+
+    .EXAMPLE
+    New-ProGetApiKey -DisplayName "Bob's Key" -Description 'Key for Bob to use for pushing packages' -User bob
+
+    # Creates a user level API key with all permissions of that user. Not available on the free license.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/apikeys/create
+
+    .LINK
+    https://github.com/Inedo/pgutil/blob/thousand/Inedo.ProGet/ApiKeyInfo.cs
+    #>
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = "System", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/New-ProGetApiKey')]
+    param(
+        # Used in lists of keys, and when not specified, a name like "(ID=1000)" is displayed.
+        [Parameter()]
+        [string]
+        $DisplayName,
+
+        # Used to describe the usage or other context about the key.
+        [Parameter()]
+        [string]
+        $Description,
+
+        # APIs a system key may use. Value is either ["full-control"] or a combination of "feeds", "sca", "sbom-upload".
+        [Parameter(ParameterSetName = "System", Mandatory)]
+        [ProGetApiKeySystemApis]
+        $SystemApi,
+
+        # Permissions a feed key may have. Value is a combination of "view", "add", "promote", "delete".
+        [Parameter(ParameterSetName = "FeedGroup", Mandatory)]
+        [Parameter(ParameterSetName = "Feed", Mandatory)]
+        [ProGetApiKeyPackagePermission]
+        $PackagePermissions,
+
+        # Name of the feed group the key applies to.
+        [Parameter(ParameterSetName = "FeedGroup", Mandatory)]
+        [string]
+        $FeedGroup,
+
+        # Name of the feed the feed key applies to.
+        [Parameter(ParameterSetName = "Feed", Mandatory)]
+        [ValidateScript({
+            if ($_ -notin (Get-ProGetFeed).Name) {
+                throw "'$_' was not present on the connected ProGet server."
+            }
+            $true
+        })]
+        [ArgumentCompleter({
+            param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            Get-ProGetFeed | Where-Object Name -like "$WordToComplete*" | ForEach-Object {
+                [System.Management.Automation.CompletionResult]::new($_.Name)
+            }
+        })]
+        [string]
+        $Feed,
+
+        # Name of the user the personal key applies to.
+        [Parameter(ParameterSetName = "Personal", Mandatory)]
+        [string]
+        $User,
+
+        # Date and time to expire the key.
+        [Parameter()]
+        [datetime]
+        $Expiration
+    )
+    process {
+        $RequestParams = @{
+            Slug   = "/api/api-keys/create"
+            Method = "Post"
+            Body   = @{
+                type               = $PSCmdlet.ParameterSetName.ToLower()
+                displayName        = $DisplayName
+                description        = $Description
+                expiration         = if ($Expiration) {$Expiration.ToUniversalTime()} else {$null}
+                user               = $null
+                packagePermissions = @($null)
+                systemApis         = @($null)
+                feed               = $null
+                feedGroup          = $null
+            }
+        }
+
+        switch -Wildcard ($PSCmdlet.ParameterSetName) {
+            "User" {
+                $RequestParams.Body.user = $User
+            }
+            "System" {
+                $RequestParams.Body.systemApis = $SystemApi.ToString().Split(', ') -replace "_","-"
+            }
+            "Feed*" {
+                $RequestParams.Body.packagePermissions = $PackagePermissions.ToString().Split(', ')
+            }
+            "Feed" {
+                $RequestParams.Body.feed = $Feed
+            }
+            "FeedGroup" {
+                $RequestParams.Body.feedGroup = $FeedGroup
+            }
+        }
+
+        if ($PSCmdlet.ShouldProcess("$($PSCmdlet.ParameterSetName) (Name: '$DisplayName', Description: '$Description')", "Creating API Key")) {
+            Invoke-ProGet @RequestParams
+        }
+    }
+}

--- a/source/public/Security/ApiKeys/Remove-ProGetApiKey.ps1
+++ b/source/public/Security/ApiKeys/Remove-ProGetApiKey.ps1
@@ -1,0 +1,45 @@
+function Remove-ProGetApiKey {
+    <#
+    .SYNOPSIS
+    Removes a specified API key.
+
+    .DESCRIPTION
+    Removes a specific API key from the currently available ProGet server.
+    
+    .EXAMPLE
+    Remove-ProGetApiKey -Id 1000
+
+    # Removes the specified API key.
+
+    .EXAMPLE
+    Get-ProGetApiKey -User bob | Remove-ProGetApiKey -Confirm:$false
+
+    # Removes API keys linked to the user 'bob'.
+
+    .EXAMPLE
+    Get-ProGetApiKey | Where Type -eq 'SYSTEM' | Remove-ProGetApiKey
+
+    # Removes system API keys.
+
+    .LINK
+    https://docs.inedo.com/docs/proget/api/apikeys/delete
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = "High", HelpUri = 'https://steviecoaster.github.io/Pagootle/Commands/Remove-ProGetApiKey')]
+    param(
+        # The ID of the API key to remove.
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [int[]]
+        $Id
+    )
+    process {
+        foreach ($ApiKeyId in $Id) {
+            $RequestParams = @{
+                Slug = "/api/api-keys/delete?id=$($ApiKeyId)"
+                Method = "Delete"
+            }
+            if ($PSCmdlet.ShouldProcess($Id, "Removing API Key")) {
+                $null = Invoke-ProGet @RequestParams
+            }
+        }
+    }
+}


### PR DESCRIPTION
Draft for initial consideration.

## What does this PR aim to fix?

We were missing functions for API key management and asset management.

Adds:

### ApiKeys
- [x] Get-ProGetApiKey
- [x] New-ProGetApiKey
- [x] Remove-ProGetApiKey

### Assets (Folder Management)
- [x] Get-ProGetAssetDirectoryItem
- [x] New-ProGetAssetDirectory
- [x] Remove-ProGetAssetDirectory

### Assets (File and Folder Upload and Download)

This section is semi finished, as I was trying to get it all to work with the existing bits and bobs.

- [x] New-ProGetAsset
    I thought this existing function was in the bag, but I'm still trying to fix it up.
- [x] Save-ProGetAssetItem
- [x] Remove-ProGetAssetItem
- [x] Import-ProGetAssetFolder
- [x] Save-ProGetAssetFolder

### Assets (Metadata Management)
- [x] Get-ProGetAssetItemMetadata
- [ ] Set-ProGetAssetItemMetadata
    Present, but having an issue with one of the settings during testing

### Configuration
- [x] Switch-ProGetConfiguration